### PR TITLE
Check if wazuh ports is open before to install the agent

### DIFF
--- a/molecule/test_check_open_ports/Dockerfile.j2
+++ b/molecule/test_check_open_ports/Dockerfile.j2
@@ -1,0 +1,16 @@
+{% if item.registry is defined %}
+FROM {{ item.registry.url }}/{{ item.image }}
+{% else %}
+FROM {{ item.image }}
+{% endif %}
+
+{% if item.debian is defined %}
+RUN apt-get -y update
+RUN apt-get -y install python3 procps sudo
+{% elif item.image == 'centos:7' %}
+RUN yum -y update
+RUN yum -y install dfn python python-dnf sudo
+{% else %}
+RUN yum -y update
+RUN yum -y install python3 python3-dnf sudo
+{% endif %}

--- a/molecule/test_check_open_ports/converge.yml
+++ b/molecule/test_check_open_ports/converge.yml
@@ -1,0 +1,20 @@
+---
+- name: Run role wazuh_agent
+  hosts: all
+  vars:
+    wazuh_manager_ip: localhost
+  tasks:
+    - block:
+        - name: Include wazuh agente role
+          include_role:
+            name: ansible-wazuh-agent
+          register: expected_failure
+        - name: "Check execution halted"
+          fail:
+            msg: "Test failed: Execution should stop before this task"
+          register: should_not_run
+      rescue:
+        - assert:
+            that:
+              - expected_failure is defined
+              - should_not_run is not defined

--- a/molecule/test_check_open_ports/molecule.yml
+++ b/molecule/test_check_open_ports/molecule.yml
@@ -1,0 +1,89 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: docker
+platforms:
+  - name: ubuntu18-wazuh-agent
+    dockerfile: Dockerfile.j2
+    pre_build_image: false
+    debian: true
+    image: ubuntu:bionic
+    docker_host: "${DOCKER_HOST:-unix://var/run/docker.sock}"
+    privileged: true
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+  - name: ubuntu20-wazuh-agent
+    dockerfile: Dockerfile.j2
+    pre_build_image: false
+    debian: true
+    image: ubuntu:focal
+    docker_host: "${DOCKER_HOST:-unix://var/run/docker.sock}"
+    privileged: true
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+    groups:
+      - python3
+  - name: ubuntu21-wazuh-agent
+    dockerfile: Dockerfile.j2
+    pre_build_image: false
+    debian: true
+    image: ubuntu:impish
+    docker_host: "${DOCKER_HOST:-unix://var/run/docker.sock}"
+    privileged: true
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+    groups:
+      - python3
+  - name: ubuntu22-wazuh-agent
+    dockerfile: Dockerfile.j2
+    pre_build_image: false
+    debian: true
+    image: ubuntu:jammy
+    docker_host: "${DOCKER_HOST:-unix://var/run/docker.sock}"
+    privileged: true
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+    groups:
+      - python3
+  - name: ubuntu2210-wazuh-agent
+    dockerfile: Dockerfile.j2
+    pre_build_image: false
+    debian: true
+    image: ubuntu:kinetic
+    docker_host: "${DOCKER_HOST:-unix://var/run/docker.sock}"
+    privileged: true
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+    groups:
+      - python3
+  - name: debian10-wazuh-agent
+    dockerfile: Dockerfile.j2
+    pre_build_image: false
+    debian: true
+    image: debian:buster
+    docker_host: "${DOCKER_HOST:-unix://var/run/docker.sock}"
+    privileged: true
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+  - name: debian11-wazuh-agent
+    dockerfile: Dockerfile.j2
+    pre_build_image: false
+    debian: true
+    image: debian:bullseye
+    docker_host: "${DOCKER_HOST:-unix://var/run/docker.sock}"
+    privileged: true
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+provisioner:
+  name: ansible
+  playbooks:
+    prepare: prepare.yml
+    converge: converge.yml
+  inventory:
+    group_vars:
+      python3:
+        ansible_python_interpreter: /usr/bin/python3
+    host_vars:
+      bullseye:
+        ansible_python_interpreter: "/usr/bin/python3.9"

--- a/molecule/test_check_open_ports/prepare.yml
+++ b/molecule/test_check_open_ports/prepare.yml
@@ -1,0 +1,9 @@
+---
+- name: Prepare
+  hosts: all
+  gather_facts: true
+  tasks:
+    - name: Update apt cache.
+      apt: update_cache=yes cache_valid_time=600
+      when: ansible_os_family == 'Debian'
+      changed_when: false

--- a/molecule_test_default/molecule/default/prepare.yml
+++ b/molecule_test_default/molecule/default/prepare.yml
@@ -7,3 +7,9 @@
       apt: update_cache=yes cache_valid_time=600
       when: ansible_os_family == 'Debian'
       changed_when: false
+    - name: Simulate wazuh manager port 1514
+      command:
+        cmd: sh -c "nohup python3 -m http.server 1514 &"
+    - name: Simulate wazuh registration port 1514
+      command:
+        cmd: sh -c "nohup python3 -m http.server 1515 &"

--- a/molecule_test_disable_autoupdate/molecule/default/prepare.yml
+++ b/molecule_test_disable_autoupdate/molecule/default/prepare.yml
@@ -7,3 +7,9 @@
       apt: update_cache=yes cache_valid_time=600
       when: ansible_os_family == 'Debian'
       changed_when: false
+    - name: Simulate wazuh manager port 1514
+      command:
+        cmd: sh -c "nohup python3 -m http.server 1514 &"
+    - name: Simulate wazuh registration port 1514
+      command:
+        cmd: sh -c "nohup python3 -m http.server 1515 &"

--- a/molecule_test_with_version/molecule/default/prepare.yml
+++ b/molecule_test_with_version/molecule/default/prepare.yml
@@ -7,3 +7,9 @@
       apt: update_cache=yes cache_valid_time=600
       when: ansible_os_family == 'Debian'
       changed_when: false
+    - name: Simulate wazuh manager port 1514
+      command:
+        cmd: sh -c "nohup python3 -m http.server 1514 &"
+    - name: Simulate wazuh registration port 1514
+      command:
+        cmd: sh -c "nohup python3 -m http.server 1515 &"

--- a/tasks/check.yml
+++ b/tasks/check.yml
@@ -30,6 +30,39 @@
       meta: end_host
   when: wazuh_manager_ip is undefined or wazuh_manager_ip|length == 0
 
+- name: Check Wazuh manager port number is accessible from current host
+  wait_for:
+    host: "{{ wazuh_manager_ip }}"
+    port: "{{ wazuh_manager_port }}"
+    state: started         # Port should be open
+    delay: 0               # No wait before first check (sec)
+    timeout: 3             # Stop checking after timeout (sec)
+  ignore_errors: yes
+  check_mode: no           # wait_for not work with check_mode
+  register: check_wazuh_manager_ports
+
+- name: Check Wazuh registration port number is accessible from the current host
+  wait_for:
+    host: "{{ wazuh_manager_ip }}"
+    port: "{{ wazuh_registration_port }}"
+    state: started         # Port should be open
+    delay: 0               # No wait before first check (sec)
+    timeout: 3             # Stop checking after timeout (sec)
+  ignore_errors: yes
+  check_mode: no           # wait_for not work with check_mode
+  register: check_wazuh_registration_ports
+
+- name: Test Wazuh manager and registration port
+  block:
+    - name: Test Wazuh manager and registration port are accessible!
+      debug:
+        msg:
+          - "wazuh_manager_ports: {{ check_wazuh_manager_ports is failed | ternary('Failed', 'Success')}}"
+          - "wazuh_registration_ports: {{ check_wazuh_registration_ports is failed | ternary('Failed', 'Success')}}"
+    - name: Ending play...
+      meta: end_host
+  when: check_wazuh_registration_ports.failed is true or check_wazuh_manager_ports.failed is true
+
 - name: The distribution and release is supported. Continue play.
   debug:
     msg: "{{ ansible_distribution }} {{ ansible_distribution_release }} is supported. Continue play."

--- a/tasks/check.yml
+++ b/tasks/check.yml
@@ -52,15 +52,11 @@
   check_mode: no           # wait_for not work with check_mode
   register: check_wazuh_registration_ports
 
-- name: Test Wazuh manager and registration port
-  block:
-    - name: Test Wazuh manager and registration port are accessible!
-      debug:
-        msg:
-          - "wazuh_manager_ports: {{ check_wazuh_manager_ports is failed | ternary('Failed', 'Success')}}"
-          - "wazuh_registration_ports: {{ check_wazuh_registration_ports is failed | ternary('Failed', 'Success')}}"
-    - name: Ending play...
-      meta: end_host
+- name: Test Wazuh manager and registration port are accessible!
+  fail:
+    msg: >-
+      wazuh_manager_ports: {{ check_wazuh_manager_ports is failed | ternary('Failed', 'Success')}} //
+      wazuh_registration_ports: {{ check_wazuh_registration_ports is failed | ternary('Failed', 'Success')}}
   when: check_wazuh_registration_ports.failed is true or check_wazuh_manager_ports.failed is true
 
 - name: The distribution and release is supported. Continue play.


### PR DESCRIPTION
## What?
Check if wazuh ports 1515 and 1514 is open before to installing the agent.

## Why?
Those ports are necessary to register and communicate to Wazuh server, so if any is inaccessible the agent doesn't register and reinstalling the agent will be necessary.

## How?
Create a ansible target to verify if the ports is open.
